### PR TITLE
Fix for upstream issue 4378,

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "style": "dist/css/tabulator.css",
   "main": "dist/js/tabulator.js",
   "module": "dist/js/tabulator_esm.js",
+  "type": "module",
   "sideEffects": [
     "**/*.css",
     "**/*.scss"


### PR DESCRIPTION
add package.json entry for type=module to enable Vite to detect the package as a module not as a main.